### PR TITLE
Fix items being dropped by the player not appearing in the DespawnedItems loot pool.

### DIFF
--- a/src/main/java/me/sebastian420/PandaArcheology/mixin/PlayerInventoryMixin.java
+++ b/src/main/java/me/sebastian420/PandaArcheology/mixin/PlayerInventoryMixin.java
@@ -1,0 +1,43 @@
+package me.sebastian420.PandaArcheology.mixin;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Nameable;
+import net.minecraft.util.collection.DefaultedList;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+
+
+@Mixin(PlayerInventory.class)
+public abstract class PlayerInventoryMixin implements Inventory, Nameable {
+
+    @Shadow
+    @Final
+    private List<DefaultedList<ItemStack>> combinedInventory;
+
+    @Shadow
+    @Final
+    public PlayerEntity player;
+
+    @Inject(at=@At(value = "INVOKE"), method = "dropAll()V")
+    public void onDropAll(CallbackInfo ci){
+        for (List<ItemStack> list : this.combinedInventory) {
+            for (int i = 0; i < list.size(); i++) {
+                ItemStack itemStack = (ItemStack)list.get(i);
+                if (!itemStack.isEmpty()) {
+                    this.player.dropItem(itemStack, true, true);
+                    list.set(i, ItemStack.EMPTY);
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/panda-archeology.mixins.json
+++ b/src/main/resources/panda-archeology.mixins.json
@@ -5,7 +5,8 @@
   "mixins": [
     "BrushBlockMixin",
     "FishCatchMixin",
-    "ItemEntityDespawn"
+    "ItemEntityDespawn",
+    "PlayerInventoryMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Quick mixin to make items dropped by the player on death retain their ownership.